### PR TITLE
Add AI API and offline sync test coverage

### DIFF
--- a/detox.config.js
+++ b/detox.config.js
@@ -1,0 +1,28 @@
+module.exports = {
+  testRunner: {
+    jest: {
+      setupTimeout: 120000,
+    },
+  },
+  apps: {
+    'android.debug': {
+      type: 'android.apk',
+      binaryPath: 'android/app/build/outputs/apk/debug/app-debug.apk',
+      build: 'cd android && ./gradlew assembleDebug assembleAndroidTest && cd ..',
+    },
+  },
+  devices: {
+    emulator: {
+      type: 'android.emulator',
+      device: {
+        avdName: 'Pixel_API_31_AOSP',
+      },
+    },
+  },
+  configurations: {
+    'android.debug': {
+      device: 'emulator',
+      app: 'android.debug',
+    },
+  },
+};

--- a/e2e/onboarding-chat-offline.test.ts
+++ b/e2e/onboarding-chat-offline.test.ts
@@ -1,0 +1,18 @@
+describe('Onboarding to Chat offline/online flow', () => {
+  beforeAll(async () => {
+    await device.launchApp({ delete: true });
+  });
+
+  it('completes onboarding and enters chat', async () => {
+    await waitFor(element(by.id('onboarding-start'))).toBeVisible().withTimeout(5000);
+    await element(by.id('onboarding-start')).tap();
+    await waitFor(element(by.id('chat-screen'))).toBeVisible().withTimeout(10000);
+  });
+
+  it('handles offline to online transition', async () => {
+    await device.setURLBlacklist(['.*']);
+    await expect(element(by.text('Offline'))).toBeVisible();
+    await device.setURLBlacklist([]);
+    await expect(element(by.text('Offline'))).not.toBeVisible();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/__tests__/**/*.test.ts'],
+};

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "import-guard": "node scripts/import-guard.js",
     "safe-point": "./scripts/create-safe-point.sh",
     "test-ai": "node scripts/test-ai-integration.js",
-    "pre-commit": "npm run import-guard"
+    "pre-commit": "npm run import-guard",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.0",
@@ -79,7 +80,10 @@
     "@types/react": "~19.0.10",
     "babel-plugin-module-resolver": "^5.0.2",
     "glob": "^11.0.3",
-    "typescript": "~5.8.3"
+    "typescript": "~5.8.3",
+    "@types/jest": "^29.5.12",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   },
   "private": true
 }

--- a/services/__tests__/offlineSync.test.ts
+++ b/services/__tests__/offlineSync.test.ts
@@ -1,0 +1,79 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { OfflineSyncService } from '../offlineSync';
+import { apiService } from '../api';
+
+jest.mock('@react-native-community/netinfo', () => ({
+  addEventListener: jest.fn(() => jest.fn()),
+}));
+
+const store: Record<string, string> = {};
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn((key: string) => Promise.resolve(store[key] || null)),
+    setItem: jest.fn((key: string, value: string) => {
+      store[key] = value;
+      return Promise.resolve();
+    }),
+  },
+}));
+
+jest.mock('../api', () => ({
+  apiService: {
+    compulsions: { update: jest.fn(), create: jest.fn(), delete: jest.fn() },
+    erp: { createExercise: jest.fn(), completeSession: jest.fn() },
+    user: { updateProfile: jest.fn() },
+  },
+}));
+
+const resetStore = () => {
+  for (const key in store) delete store[key];
+};
+
+const service = OfflineSyncService.getInstance();
+(service as any).isOnline = true;
+
+beforeEach(() => {
+  resetStore();
+  (service as any).syncQueue = [];
+  jest.clearAllMocks();
+});
+
+describe('OfflineSyncService', () => {
+  test('retains item on conflict error', async () => {
+    (apiService.compulsions.update as jest.Mock).mockRejectedValue({ response: { status: 409 } });
+
+    (service as any).syncQueue = [{
+      id: '1',
+      type: 'UPDATE',
+      entity: 'compulsion',
+      data: { id: '1' },
+      timestamp: Date.now(),
+      retryCount: 0,
+    }];
+
+    await service.processSyncQueue();
+
+    expect((service as any).syncQueue).toHaveLength(1);
+    expect((service as any).syncQueue[0].retryCount).toBe(1);
+  });
+
+  test('stores item after RLS violation', async () => {
+    (apiService.user.updateProfile as jest.Mock).mockRejectedValue({ response: { status: 403 } });
+
+    (service as any).syncQueue = [{
+      id: '2',
+      type: 'UPDATE',
+      entity: 'user_progress',
+      data: {},
+      timestamp: Date.now(),
+      retryCount: 2,
+    }];
+
+    await service.processSyncQueue();
+
+    expect((service as any).syncQueue).toHaveLength(0);
+    const failed = JSON.parse((await AsyncStorage.getItem('failedSyncItems')) || '[]');
+    expect(failed).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- expand AI integration script with live API, error, and timeout checks
- add Jest unit tests for offline sync conflicts and RLS violations
- introduce Detox e2e flow from onboarding to chat with offline/online transition

## Testing
- `node scripts/test-ai-integration.js`
- `npm test` *(fails: jest not found)*
- `npx detox test` *(fails: 403 Forbidden fetching package)*
- `npm run import-guard`


------
https://chatgpt.com/codex/tasks/task_e_6897733a20208329a279f2aa849a77de