### PR TITLE
feat: improve AI telemetry monitoring and resilience

### DIFF
--- a/features/ai/telemetry/__tests__/aiTelemetry.test.ts
+++ b/features/ai/telemetry/__tests__/aiTelemetry.test.ts
@@ -1,0 +1,35 @@
+import { trackAIInteraction, AIEventType, __testing } from '../aiTelemetry';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(null),
+  removeItem: jest.fn().mockResolvedValue(null),
+}));
+
+jest.mock('react-native', () => ({
+  InteractionManager: {
+    runAfterInteractions: (cb: any) => cb(),
+  },
+}));
+
+describe('AI Telemetry flush failures', () => {
+  beforeAll(() => {
+    (global as any).__DEV__ = true;
+  });
+
+  it('keeps events in buffer when flush fails', async () => {
+    const manager: any = __testing.telemetryManager;
+    jest.spyOn(manager, 'saveEventsToStorage').mockRejectedValue(new Error('storage fail'));
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await trackAIInteraction(AIEventType.SYSTEM_STARTED, {});
+    expect(manager.eventBuffer.length).toBe(1);
+
+    await manager.flushBuffer();
+
+    expect(errorSpy).toHaveBeenCalled();
+    expect(manager.eventBuffer.length).toBe(1);
+
+    errorSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- monitor AI interactions with latency, success rate and error type
- wrap AsyncStorage calls in InteractionManager and flush telemetry queue
- add test for failed telemetry flush retaining events

## Testing
- `npm run pre-commit`
- `npx jest features/ai/telemetry/__tests__/aiTelemetry.test.ts` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*
- `npm install --save-dev jest @types/jest ts-node ts-jest` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@types%2fjest)*

------
https://chatgpt.com/codex/tasks/task_e_6897733040948329964bb75cd5c0f26c