### PR TITLE
feat: track suggestion usage and show progress trends

### DIFF
--- a/app/(tabs)/progress.tsx
+++ b/app/(tabs)/progress.tsx
@@ -1,0 +1,79 @@
+import React, { useEffect, useState } from 'react';
+import { View, StyleSheet, Dimensions } from 'react-native';
+import { LineChart } from 'react-native-chart-kit';
+import ScreenLayout from '@/components/layout/ScreenLayout';
+import { getSuggestionStats } from '@/features/ai/telemetry/aiTelemetry';
+import { useTranslation } from '@/hooks/useTranslation';
+
+export default function ProgressScreen() {
+  const { t } = useTranslation();
+  const [acceptanceData, setAcceptanceData] = useState<number[]>([0, 0, 0]);
+  const [usageData, setUsageData] = useState<number[]>([0, 0, 0]);
+
+  useEffect(() => {
+    const seven = getSuggestionStats(7);
+    const thirty = getSuggestionStats(30);
+    const ninety = getSuggestionStats(90);
+
+    setAcceptanceData([
+      seven.acceptanceRate * 100,
+      thirty.acceptanceRate * 100,
+      ninety.acceptanceRate * 100,
+    ]);
+
+    setUsageData([seven.usage, thirty.usage, ninety.usage]);
+  }, []);
+
+  return (
+    <ScreenLayout>
+      <View style={styles.container}>
+        <LineChart
+          data={{
+            labels: ['7d', '30d', '90d'],
+            datasets: [
+              {
+                data: acceptanceData,
+                color: () => '#3b82f6',
+                strokeWidth: 2,
+              },
+              {
+                data: usageData,
+                color: () => '#10b981',
+                strokeWidth: 2,
+              },
+            ],
+            legend: [t('progress.acceptance'), t('progress.usage')],
+          }}
+          width={Dimensions.get('window').width - 32}
+          height={220}
+          chartConfig={{
+            backgroundColor: '#ffffff',
+            backgroundGradientFrom: '#ffffff',
+            backgroundGradientTo: '#ffffff',
+            decimalPlaces: 2,
+            color: (opacity = 1) => `rgba(59,130,246,${opacity})`,
+            labelColor: (opacity = 1) => `rgba(107,114,128,${opacity})`,
+            propsForDots: {
+              r: '4',
+              strokeWidth: '2',
+              stroke: '#1e3a8a',
+            },
+          }}
+          style={styles.chart}
+        />
+      </View>
+    </ScreenLayout>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 16,
+  },
+  chart: {
+    marginVertical: 8,
+    borderRadius: 16,
+  },
+});
+

--- a/features/ai/analytics/progressAnalytics.ts
+++ b/features/ai/analytics/progressAnalytics.ts
@@ -881,6 +881,51 @@ class ProgressAnalytics {
     return ProgressTrend.STABLE;
   }
 
+  /**
+   * Calculate trend for a given period in days
+   */
+  private calculateTrendForPeriod(points: ProgressDataPoint[], days: number): ProgressTrend {
+    const cutoff = new Date(Date.now() - days * 24 * 60 * 60 * 1000);
+    const periodPoints = points
+      .filter(p => p.timestamp >= cutoff)
+      .sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+
+    if (periodPoints.length < 2) return ProgressTrend.STABLE;
+
+    const start = periodPoints[0].normalizedValue;
+    const end = periodPoints[periodPoints.length - 1].normalizedValue;
+    const changePercent = ((end - start) / start) * 100;
+
+    if (changePercent >= 25) return ProgressTrend.SIGNIFICANT_IMPROVEMENT;
+    if (changePercent >= 10) return ProgressTrend.MODERATE_IMPROVEMENT;
+    if (changePercent >= 5) return ProgressTrend.SLIGHT_IMPROVEMENT;
+    if (changePercent <= -25) return ProgressTrend.SIGNIFICANT_DECLINE;
+    if (changePercent <= -10) return ProgressTrend.MODERATE_DECLINE;
+    if (changePercent <= -5) return ProgressTrend.SLIGHT_DECLINE;
+    return ProgressTrend.STABLE;
+  }
+
+  /**
+   * 7-day trend
+   */
+  calculate7DayTrend(points: ProgressDataPoint[]): ProgressTrend {
+    return this.calculateTrendForPeriod(points, 7);
+  }
+
+  /**
+   * 30-day trend
+   */
+  calculate30DayTrend(points: ProgressDataPoint[]): ProgressTrend {
+    return this.calculateTrendForPeriod(points, 30);
+  }
+
+  /**
+   * 90-day trend
+   */
+  calculate90DayTrend(points: ProgressDataPoint[]): ProgressTrend {
+    return this.calculateTrendForPeriod(points, 90);
+  }
+
   private extractKeyMetricsForCategory(points: ProgressDataPoint[]): ProgressAnalyticsResult['categoryProgress'][0]['keyMetrics'] {
     return points.map(point => ({
       metric: point.metric,


### PR DESCRIPTION
## Summary
- add 7/30/90 day trend helpers to progress analytics
- log suggestion usage and acceptance metrics in telemetry
- add progress tab with line chart visualising suggestion stats

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run pre-commit`


------
https://chatgpt.com/codex/tasks/task_e_6897732dbccc8329b62d17c1b3abb35d